### PR TITLE
dcm.sh - Switch to [[extended test command]] for zsh support.

### DIFF
--- a/dcm.sh
+++ b/dcm.sh
@@ -4,13 +4,13 @@ dcm() {
   local ARCH=$(uname -m)
   local BIN=$DCM_DIR/bin
 
-  if [ "$OS" == "Darwin" ] && [ "$ARCH" == "x86_64" ]; then
+  if [[ "$OS" == "Darwin" ]] && [[ "$ARCH" == "x86_64" ]]; then
     BIN=$BIN/dcm-darwin-amd64
-  elif [ "$OS" == "Linux" ] && [ "$ARCH" == "x86_64" ]; then
+  elif [[ "$OS" == "Linux" ]] && [[ "$ARCH" == "x86_64" ]]; then
     BIN=$BIN/dcm-linux-amd64
-  elif [ "$OS" == "FreeBSD" ] && [ "$ARCH" == "x86_64" ]; then
+  elif [[ "$OS" == "FreeBSD" ]] && [[ "$ARCH" == "x86_64" ]]; then
     BIN=$BIN/dcm-freebsd-amd64
-  elif [ "$OS" == "CYGWIN_NT-6.1" ] && [ "$ARCH" == "x86_64" ]; then
+  elif [[ "$OS" == "CYGWIN_NT-6.1" ]] && [[ "$ARCH" == "x86_64" ]]; then
     BIN=$BIN/dcm-windows-amd64.exe
   else
     >&2 echo "Sorry, your OS ($OS) and Arch ($ARCH) is not currently supported by DCM." && \


### PR DESCRIPTION
Something like this doesn't work in zsh:
```
if [ "abc" == "def" ]; then echo y; else echo n; fi
```

It will produce an error like this:

```
zsh: = not found
```

It looks like double square brackets is the more robust way of doing things, some reading if you'd like: 
http://www.unix.com/shell-programming-and-scripting/98489-why-different-then.html

I've tested this and it still works in bash.